### PR TITLE
To avoid:

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,8 @@
 plugins {
     id 'com.android.application'
     id 'kotlin-android'
+    id 'kotlin-kapt'
+
 }
 
 android {
@@ -16,6 +18,7 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
+
     buildTypes {
         release {
             minifyEnabled false
@@ -26,6 +29,7 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
     kotlinOptions {
         jvmTarget = '1.8'
     }
@@ -35,7 +39,12 @@ dependencies {
 
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'
     implementation 'com.squareup.retrofit2:converter-moshi:2.9.0'
-    implementation 'com.github.bumptech.glide:glide:4.10.0'
+    implementation 'com.github.bumptech.glide:glide:4.11.0'
+    kapt 'com.github.bumptech.glide:compiler:4.11.0'
+
+
+
+
 
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.4.1'

--- a/app/src/main/java/com/eyehail/readingdataweather/Api/GlideImageLoader.kt
+++ b/app/src/main/java/com/eyehail/readingdataweather/Api/GlideImageLoader.kt
@@ -1,0 +1,15 @@
+package com.eyehail.readingdataweather.Api
+
+import android.content.Context
+import android.widget.ImageView
+import com.bumptech.glide.Glide
+
+class GlideImageLoader(private val context: Context): ImageLoader {
+
+    override fun loadImage(imageUrl: String, imageView: ImageView) {
+        Glide.with(context)
+            .load(imageUrl)
+            .centerCrop()
+            .into(imageView)
+    }
+}

--- a/app/src/main/java/com/eyehail/readingdataweather/Api/ImageLoader.kt
+++ b/app/src/main/java/com/eyehail/readingdataweather/Api/ImageLoader.kt
@@ -1,0 +1,10 @@
+package com.eyehail.readingdataweather.Api
+
+import android.widget.ImageView
+
+interface ImageLoader {
+    fun loadImage(
+        imageUrl: String,
+        imageView: ImageView
+    )
+}

--- a/app/src/main/java/com/eyehail/readingdataweather/Api/TheWeatherApiService.kt
+++ b/app/src/main/java/com/eyehail/readingdataweather/Api/TheWeatherApiService.kt
@@ -6,6 +6,6 @@ import retrofit2.http.GET
 
 interface TheWeatherApiService {
     //change token and lat and lon
-    @GET("weather?lat=00&lon=00&appid={token}")
+    @GET("weather?lat=62.035454&lon=129.675476&appid=4e9f768bcdb68a62161bd4ed2432db87")
     fun returnWeather(): Call<WeatherData>
 }

--- a/app/src/main/java/com/eyehail/readingdataweather/MainActivity.kt
+++ b/app/src/main/java/com/eyehail/readingdataweather/MainActivity.kt
@@ -3,7 +3,10 @@ package com.eyehail.readingdataweather
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.util.Log
+import android.widget.ImageView
 import android.widget.TextView
+import com.eyehail.readingdataweather.Api.GlideImageLoader
+import com.eyehail.readingdataweather.Api.ImageLoader
 import com.eyehail.readingdataweather.Api.TheWeatherApiService
 import com.eyehail.readingdataweather.Model.WeatherData
 import retrofit2.Call
@@ -28,6 +31,12 @@ class MainActivity : AppCompatActivity() {
     private val serverResponseWeather : TextView by lazy {
         findViewById(R.id.weather)
     }
+    private val profileImageView: ImageView by lazy {
+        findViewById(R.id.image)
+    }
+    private val imageLoader: ImageLoader by lazy {
+        GlideImageLoader(this)
+    }
     override fun onCreate(savedInstanceState: Bundle?) {
 
         super.onCreate(savedInstanceState)
@@ -51,6 +60,14 @@ class MainActivity : AppCompatActivity() {
                     serverResponseCity.text = cityResponse
                     val temperatureResponse = weatherResults?.main?.temp ?: "No Temperature"
                     serverResponseWeather.text = temperatureResponse
+                    Log.e("Main Activity", "https://openweathermap.org/img/wn/${weatherResults?.weather?.get(0)}@2x.png")
+                    val firstImageUrl = "https://openweathermap.org/img/wn/${weatherResults?.weather?.firstOrNull()?.icon}@2x.png"
+                    if (!firstImageUrl.isBlank()) {
+                        imageLoader.loadImage(firstImageUrl, profileImageView)
+                    } else {
+                        Log.d("Main Activity", "Missing Image Url")
+                    }
+
 
                 } else {
                     Log.e("Main Activity", "Failed to get search results \n" +

--- a/app/src/main/java/com/eyehail/readingdataweather/Model/ImageData.kt
+++ b/app/src/main/java/com/eyehail/readingdataweather/Model/ImageData.kt
@@ -1,0 +1,7 @@
+package com.eyehail.readingdataweather.Model
+
+import com.squareup.moshi.Json
+
+data class ImageData(
+    val icon: String
+)

--- a/app/src/main/java/com/eyehail/readingdataweather/Model/WeatherData.kt
+++ b/app/src/main/java/com/eyehail/readingdataweather/Model/WeatherData.kt
@@ -2,5 +2,6 @@ package com.eyehail.readingdataweather.Model
 
 data class WeatherData(
     val name: String,
-    val main: MainData
+    val main: MainData,
+    val weather: List<ImageData>
 )

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -30,10 +30,10 @@
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_bias="0.138" />
 
-    <TextView
+    <ImageView
         android:id="@+id/image"
-        android:layout_width="150dp"
-        android:layout_height="150dp"
+        android:layout_width="300dp"
+        android:layout_height="300dp"
 
         android:hint="IMAGE"
         app:layout_constraintBottom_toBottomOf="parent"

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,8 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        maven { url "https://jitpack.io" }
+
     }
     dependencies {
         classpath "com.android.tools.build:gradle:7.0.4"


### PR DESCRIPTION
E/Main Activity: https://openweathermap.org/img/wn/ImageData(icon=03n)@2x.png
2022-04-10 14:30:46.431 5365-5365/com.eyehail.readingdataweather W/Glide: Failed to find GeneratedAppGlideModule. You should include an annotationProcessor compile dependency on com.github.bumptech.glide:compiler in your application and a @GlideModule annotated AppGlideModule implementation or LibraryGlideModules will be silently ignored
2022-04-10 14:30:50.933 5365-5416/com.eyehail.readingdataweather W/ExifInterface: Invalid image: ExifInterface got an unsupported image format file(ExifInterface supports JPEG and some RAW image formats only) or a corrupted JPEG file to ExifInterface.

in build.gradle(Module)
implementation 'com.github.bumptech.glide:glide:4.11.0'
kapt 'com.github.bumptech.glide:compiler:4.11.0'